### PR TITLE
feat(kbTimer): introduce `chorno` for time calculation

### DIFF
--- a/KickBoxerTickerForVmix/kbTimer/kbTimer.cpp
+++ b/KickBoxerTickerForVmix/kbTimer/kbTimer.cpp
@@ -2,26 +2,18 @@
 // compile with: /EHsc
 #include <stdio.h>
 #include <agents.h>
-#include <time.h>
+#include <chrono>
 #include <windows.h>
 #include <iostream>
-#include <chrono>
 #include <string>
 
-
-namespace ccr = concurrency; // using namespace ccr; using namespace concurrency
+namespace ccr = concurrency;
 using namespace std;
 
-
-
-__time64_t long_start_time;
-__time64_t long_current_time;
-struct tm tm_timer_time;
-struct tm tm_current_time;
-errno_t err;
+std::chrono::time_point<std::chrono::system_clock> start_time;
+std::chrono::time_point<std::chrono::system_clock> current_time;
 uint32_t loop_counter;
 string call_sequence;
-
 
 /**
 * Ctrl-C handler (trap)
@@ -34,14 +26,13 @@ BOOL WINAPI CtrlHandler(DWORD fdwCtrlType)
         printf("\n\nCtrl- event code (return true): %d\n\n", fdwCtrlType);
         Beep(500, 300);
         return FALSE;
-    
+
     case CTRL_LOGOFF_EVENT: case CTRL_SHUTDOWN_EVENT: default:
         Beep(750, 500);
         printf("\n\nCtrl- event code (return false): %d\n\n", fdwCtrlType);
         return TRUE;
     }
 }
-
 
 /**
 * Simulates a lengthy operation.
@@ -50,13 +41,11 @@ void perform_lengthy_operation()
 {
     call_sequence += ">>> " + to_string(loop_counter) + " <<<   ";
     for (int i = 1; i <= 10; i++) {
-        // for (uint64_t i = 0; i < 3000000000; i++) { __nop(); };
-        ccr::wait(3300);      // Yield the current context for XXXX milliseconds
+        ccr::wait(3300);      // Yield the current context for 3300 milliseconds
         printf("          >>>%d<<<", loop_counter);
         loop_counter++;
     }
 }
-
 
 int main()
 {
@@ -64,43 +53,41 @@ int main()
     * Create a call object that prints a single character to the console.
     */
     ccr::call<wchar_t> report_progress([](wchar_t c) {
-        _time64(&long_current_time);                                // Get current time as 64-bit integer.
-        err = _localtime64_s(&tm_current_time, &long_current_time); // Convert to local time
-        long_start_time++;                                          // Increment start time for 1 second    
+        current_time = std::chrono::system_clock::now();
+        auto elapsed_seconds = std::chrono::duration_cast<std::chrono::seconds>(current_time - start_time).count();
         call_sequence += " " + to_string(loop_counter);
-        _localtime64_s(&tm_timer_time, &long_start_time);           // Convert to local time
 
-        wcout << char(0xD);
-        printf("%02d:%02d", tm_timer_time.tm_min, tm_timer_time.tm_sec);
-        // wcout << newtime.tm_min << ":" << newtime.tm_sec;
+        std::chrono::time_point<std::chrono::system_clock> timer_time = start_time + std::chrono::seconds(elapsed_seconds);
+
+        auto start_min = std::chrono::duration_cast<std::chrono::minutes>(timer_time.time_since_epoch()).count() % 60;
+        auto start_sec = std::chrono::duration_cast<std::chrono::seconds>(timer_time.time_since_epoch()).count() % 60;
+
+        auto current_min = std::chrono::duration_cast<std::chrono::minutes>(current_time.time_since_epoch()).count() % 60;
+        auto current_sec = std::chrono::duration_cast<std::chrono::seconds>(current_time.time_since_epoch()).count() % 60;
+
+        wcout << '\r';
+        printf("%02d:%02d", static_cast<int>(start_min), static_cast<int>(start_sec));
         printf("        %3d        ", loop_counter);
-        printf("%02d:%02d", tm_current_time.tm_min, tm_current_time.tm_sec); // , call_sequence.data()
-    }); 
-
-
-
-
+        printf("%02d:%02d", static_cast<int>(current_min), static_cast<int>(current_sec));
+        });
 
     if (SetConsoleCtrlHandler(CtrlHandler, TRUE))
     {
         printf("\n   ---     The Control Handler is installed.     ---\n");
         printf("   ---   Now try pressing Ctrl+C or Ctrl+Break   ---\n\n");
-        
+
         while (1) {
             /*
              * Create a timer object that sends the dot character to the call object every 1000 milliseconds.
             */
             ccr::timer<wchar_t> progress_timer(1000, L'.', &report_progress, true);
+
             /*
             * Get current system time and store it in global var
             */
-            _time64(&long_current_time);                                 // Get time as 64-bit integer.
-            err = _localtime64_s(&tm_current_time, &long_current_time);  // Convert to local time.
-            if (err)
-            { printf("Invalid argument to _localtime64_s."); exit(1); }
-            long_start_time = long_current_time;                         // Save start time
-            /**/
-            
+            current_time = std::chrono::system_clock::now();
+            start_time = current_time;
+
             loop_counter = 1;
             call_sequence = "";
             wcout << L"\n\nPerforming a lengthy operation\n\n";
@@ -108,7 +95,7 @@ int main()
             progress_timer.start();                                      // Start the timer on a separate context.
             perform_lengthy_operation();                                 // Perform a lengthy operation on the main context.
             progress_timer.stop();                                       // Stop the timer and print a message.
-            // progress_timer.~timer();
+
             wcout << L"\n\n\n\n\n\n";
         }
     }


### PR DESCRIPTION
Apparently, the `chrono` library was included as the requirement for kbTimer, but was never used. Instead, a pure C implementation of the time calculation was utilized.

This PR reworks the time calculation by fully utilizing it, thus making the code more read-able and the timer more precise.